### PR TITLE
Support more parameters in db config.

### DIFF
--- a/app/config/services.php
+++ b/app/config/services.php
@@ -37,14 +37,15 @@ $di->set('url', function () use ($config) {
 /**
  * Database connection is created based in the parameters defined in the configuration file
  */
-$di->set('db', function () use ($config) {
-    return new DbAdapter(array(
-        'host' => $config->database->host,
-        'username' => $config->database->username,
-        'password' => $config->database->password,
-        'dbname' => $config->database->dbname
-    ));
-});
+ $di->setShared('db', function () use ($config) {
+     $dbConfig = $config->database->toArray();
+     $adapter = $dbConfig['adapter'];
+     unset($dbConfig['adapter']);
+
+     $class = 'Phalcon\Db\Adapter\Pdo\\' . $adapter;
+
+     return new $class($dbConfig);
+ });
 
 /**
  * If the configuration specify the use of metadata adapter use it or use memory otherwise


### PR DESCRIPTION
Because charset parameter in config wasn't being loaded correctly in this file. DevTools generated code was inserted instead.
